### PR TITLE
Fixes digicademy/lod#12

### DIFF
--- a/Classes/ViewHelpers/EasyRdfGraphViewHelper.php
+++ b/Classes/ViewHelpers/EasyRdfGraphViewHelper.php
@@ -138,8 +138,8 @@ class EasyRdfGraphViewHelper extends AbstractViewHelper
                     $graphClassname = 'EasyRdf_Graph';
                     $namespaceClass = 'EasyRdf_Namespace';
                 } else {
-                    $graphClassname = '\EasyRdf\Graph';
-                    $namespaceClass = '\EasyRdf\Namespace';
+                    $graphClassname = 'EasyRdf\Graph';
+                    $namespaceClass = 'EasyRdf\Namespace';
                 }
 
                 // optionally set namespaces


### PR DESCRIPTION
Remove backslashes from EasyRdfGraphViewHelper.php, because backslashes lead to InvalidArgumentException 1420281366: $classname must not start with a backslash (see GeneralUtility.php line 3445).