### PR TITLE
Add extension key to composer file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
         "psr-4": {
           "Digicademy\\Lod\\": "Classes/"
         }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "lod"
+        }
     }
 }


### PR DESCRIPTION
Specifying the extension key will be mandatory in future versions of TYPO3.