### PR TITLE
Change result value if datatype and language are given

### DIFF
--- a/Classes/ViewHelpers/LangDatatypeViewHelper.php
+++ b/Classes/ViewHelpers/LangDatatypeViewHelper.php
@@ -91,6 +91,8 @@ class LangDatatypeViewHelper extends AbstractViewHelper
             $result = $languageValue;
         } elseif ($datatype && $language == '') {
             $result = $datatypeValue;
+        } elseif ($datatype && $language) {
+            $result = $languageValue;
         } else {
             $result = '';
         }


### PR DESCRIPTION
There seems to be a missing condition if a literal contains data type and language information. In this case an empty string is returned. In this commit, a condition is added so that at least the language information is returned. It would be worth considering whether a string with both information should be returned ($result = $languageValue . " " . $datatypeValue ;). 