### PR TITLE
Use a keyless array for call_user_func_array in ContentNegotiationService::processAcceptHeader to avoid PHP 8 Named Parameters error.

### DIFF
--- a/Classes/Service/ContentNegotiationService.php
+++ b/Classes/Service/ContentNegotiationService.php
@@ -233,7 +233,11 @@ class ContentNegotiationService
             }
         }
         krsort($weightedMediaTypes);
-        $sortedHttpAcceptHeaders = call_user_func_array('array_merge', $weightedMediaTypes);
+
+        // call_user_func_array will interpret the top-level array keys as
+        // parameter names to be passed into the array_merge. To avoid errors,
+        // we make a keyless array from the values.         
+        $sortedHttpAcceptHeaders = call_user_func_array('array_merge', array_values($weightedMediaTypes));
 
         return $sortedHttpAcceptHeaders;
      }


### PR DESCRIPTION
The processAcceptHeader method passes arrays with named keys in a `call_user_func_array` call. In PHP 8.3, this leads to an error message `array_merge() does not accept unknown named parameters` because PHP expects the keys of the array to be parameter names (which they aren't). 

To strip the top-level named keys and avoid this error, we can wrap the parameter array into an `array_values` call, now done in line 240.

For similar problems in different PHP contexts, see, e.g., https://stackoverflow.com/questions/69424097/uncaught-argumentcounterror-array-merge-does-not-accept-unknown-named-paramet#answer-69797665