### PR TITLE
Add existence checks for more array keys in map method to avoid PHP wa…

### DIFF
--- a/Classes/Service/ItemMappingService.php
+++ b/Classes/Service/ItemMappingService.php
@@ -152,7 +152,11 @@ class ItemMappingService
 
         foreach ($frameworkConfiguration['persistence']['classes'] as $key => $value) {
             // if current table name matches a configured table name
-            if ($value['mapping']['tableName'] == $tablename) {
+            if (
+                array_key_exists('mapping', $value) &&
+                array_key_exists('tableName', $value['mapping']) &&
+                $value['mapping']['tableName'] == $tablename
+            ) {
                 // check if recordType is configured and matches the row
                 if (array_key_exists('recordType', $value['mapping'])) {
                     $typeColumnName = $GLOBALS['TCA'][$tablename]['ctrl']['type'];


### PR DESCRIPTION
…rnings.

If the 'mapping' key does not exist, the programme continues running but triggers a PHP warning. Depending on application context, this can cause massive log file growth quickly; let's avoid this.